### PR TITLE
Remove the processing date from Item IDs.

### DIFF
--- a/src/stactools/landsat/mtl_metadata.py
+++ b/src/stactools/landsat/mtl_metadata.py
@@ -39,7 +39,19 @@ class MtlMetadata:
 
     @property
     def scene_id(self) -> str:
-        return self._get_text("PRODUCT_CONTENTS/LANDSAT_PRODUCT_ID")
+        product_id = self._get_text("PRODUCT_CONTENTS/LANDSAT_PRODUCT_ID")
+        # Remove the processing date, as products IDs
+        # that only vary by processing date represent the
+        # same scene
+        # See "Section 5 - Product Packaging" at
+        # https://prd-wret.s3.us-west-2.amazonaws.com/assets/palladium/production/atoms/files/LSDS-1619_Landsat8-C2-L2-ScienceProductGuide-v2.pdf  # noqa
+
+        # ID format: LXSS_LLLL_PPPRRR_YYYYMMDD_yyyymmdd_CX_TX
+        # remove yyyymmdd
+        id_parts = product_id.split('_')
+        id_parts = '_'.join(id_parts[:4] + id_parts[-2:])
+
+        return id_parts
 
     @property
     def processing_level(self) -> str:

--- a/tests/data.py
+++ b/tests/data.py
@@ -1,12 +1,17 @@
 from tests import test_data
 
-TEST_MTL_PATHS = [
+# Item IDs to paths
+TEST_MTL_PATHS = {
+    'LC08_L2SP_005009_20150710_02_T2':
     test_data.get_path(
         'data-files/assets/LC08_L2SP_005009_20150710_20200908_02_T2_MTL.xml'),
+    'LC08_L2SR_099120_20191129_02_T2':
     test_data.get_path(
         'data-files/assets2/LC08_L2SR_099120_20191129_20201016_02_T2_MTL.xml'),
+    'LC08_L2SP_008059_20191201_02_T1':
     test_data.get_path(
         'data-files/assets3/LC08_L2SP_008059_20191201_20200825_02_T1_MTL.xml'),
+    'LC08_L2SP_017036_20130419_02_T2':
     test_data.get_path(
         'data-files/assets4/LC08_L2SP_017036_20130419_20200913_02_T2_MTL.xml')
-]
+}

--- a/tests/test_create_stac.py
+++ b/tests/test_create_stac.py
@@ -36,7 +36,7 @@ class CreateItemTest(CliTestCase):
             self.assertLess((reproj_bbox_shp - bbox_shp).area,
                             0.0001 * reproj_bbox_shp.area)
 
-        for mtl_path in TEST_MTL_PATHS:
+        for item_id, mtl_path in TEST_MTL_PATHS.items():
             with self.subTest(mtl_path):
                 base_path = "_".join(mtl_path.split("_")[:-1])
                 tif_path = f"{base_path}_SR_B3.TIF"
@@ -64,6 +64,7 @@ class CreateItemTest(CliTestCase):
                         pystac.Link(rel="collection",
                                     target="http://example.com"))
                     item.validate()
+                    self.assertEqual(item.id, item_id)
 
                     bands_seen = set()
 
@@ -99,7 +100,7 @@ class CreateItemTest(CliTestCase):
 
             return item
 
-        for mtl_path in TEST_MTL_PATHS:
+        for mtl_path in TEST_MTL_PATHS.values():
             with self.subTest(mtl_path):
                 with TemporaryDirectory() as tmp_dir:
                     create_dir = os.path.join(tmp_dir, 'create')


### PR DESCRIPTION
Product IDs that have the same ID besides the processing date represent the same scene and therefore STAC Item. This change removes the processing date from the Item IDs to reflect that.