### PR TITLE
Add setup.py to allow for building distributions for publishing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()


### PR DESCRIPTION
The `scripts/publish` branch is currently broken because it depends on setup.py, which was removed.

This re-adds a minimal setup.py to be able to use setuptools.

There might be a better way to build distributions for publishing without setuptools or a setup.py file, but I couldn't a way that didn't add extra dependencies and a two-line file seems worth it. Please let me if there's a better method, and I'll fix in a follow up PR.