### PR TITLE
Fix GSD bug; allow docker to test dev code inside containers

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
+## Unreleased
+
+### Fixed
+
+- Fix bug in assigning GSD to assets ([#8](https://github.com/stactools-packages/landsat/pull/8))
+
+
 ## [v0.1.7]
 
 ### Changed

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -4,4 +4,8 @@ RUN conda install -c conda-forge pandoc
 
 COPY . /src/stactools-landsat
 RUN pip install -r /src/stactools-landsat/requirements-dev.txt
+
+# Set the PYTHONPATH to run locally mounted source
+ENV PYTHONPATH=/src/stactools-landsat/src:$PYTHONPATH
+
 WORKDIR /src/stactools-landsat

--- a/src/stactools/landsat/assets.py
+++ b/src/stactools/landsat/assets.py
@@ -59,7 +59,7 @@ class AssetDef:
         # common_metadata
 
         if self.gsd is not None:
-            item.common_metadata.gsd = self.gsd
+            pystac.CommonMetadata(asset).gsd = self.gsd
         else:
             if self.is_sr or self.is_qa:
                 sr_gsd = mtl_metadata.sr_gsd


### PR DESCRIPTION
This fixes a bug introduced in #5, which incorrectly set the gsd on the Item level.

Also set the PYTHONPATH inside the dev container to allow the development code that is mounted into the container to be used; add a test to cover this case.