### PR TITLE
Version 0.2.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,14 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project attempts to match the major and minor versions of [stactools](https://github.com/stac-utils/stactools) and increments the patch number as needed.
 
-## Unreleased
-
-### Fixed
-
-- Fix bug in assigning GSD to assets ([#8](https://github.com/stactools-packages/landsat/pull/8))
-
-
-## [v0.1.7]
+## [v0.2.0]
 
 ### Changed
 

--- a/src/stactools/landsat/__init__.py
+++ b/src/stactools/landsat/__init__.py
@@ -11,4 +11,4 @@ def register_plugin(registry):
     registry.register_subcommand(commands.create_landsat_command)
 
 
-__version__ = '0.1.7'
+__version__ = '0.2.0'


### PR DESCRIPTION
Previous 0.1.7 release had a bug so was yanked.

The upgrade to PySTAC 1.0 deserves a minor version upgrade, so bumping the release version to 0.2.0