### PR TITLE
Correct emissivity unit

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,10 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Nothing.
+- "emissivity" to `roles` list on the `emis` and `emsd` assets ([#47](https://github.com/stactools-packages/landsat/pull/47))
 
 ### Removed
 
+- `unit` from the `emis` and `emsd` assets (emissivity coefficient is unitless) ([#47](https://github.com/stactools-packages/landsat/pull/47))
 - `legacy_l8` option from Item creation ([#40](https://github.com/stactools-packages/landsat/pull/40))
 - Outdated `convert` command ([#40](https://github.com/stactools-packages/landsat/pull/40))
 - Unused utility functions: `_parse_date`, `transform_mtl_to_stac`, `transform_stac_to_stac`, `stac_api_to_stac` ([#40](https://github.com/stactools-packages/landsat/pull/40))

--- a/examples/landsat-c2-l1/LM01_L1GS_001010_19720908_02_T2/LM01_L1GS_001010_19720908_02_T2.json
+++ b/examples/landsat-c2-l1/LM01_L1GS_001010_19720908_02_T2/LM01_L1GS_001010_19720908_02_T2.json
@@ -7,7 +7,7 @@
     "instruments": [
       "mss"
     ],
-    "created": "2022-03-31T18:24:59.855547Z",
+    "created": "2022-10-15T16:44:21.391576Z",
     "gsd": 79,
     "description": "Landsat Collection 2 Level-1",
     "eo:cloud_cover": 43.0,
@@ -505,7 +505,7 @@
     71.65367836829611
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l1/LM02_L1GS_001004_19750411_02_T2/LM02_L1GS_001004_19750411_02_T2.json
+++ b/examples/landsat-c2-l1/LM02_L1GS_001004_19750411_02_T2/LM02_L1GS_001004_19750411_02_T2.json
@@ -7,7 +7,7 @@
     "instruments": [
       "mss"
     ],
-    "created": "2022-03-31T18:24:59.857864Z",
+    "created": "2022-10-15T16:44:21.394072Z",
     "gsd": 79,
     "description": "Landsat Collection 2 Level-1",
     "eo:cloud_cover": 100.0,
@@ -505,7 +505,7 @@
     78.65736802978886
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l1/LM03_L1GS_001001_19780510_02_T2/LM03_L1GS_001001_19780510_02_T2.json
+++ b/examples/landsat-c2-l1/LM03_L1GS_001001_19780510_02_T2/LM03_L1GS_001001_19780510_02_T2.json
@@ -7,7 +7,7 @@
     "instruments": [
       "mss"
     ],
-    "created": "2022-03-31T18:24:59.859591Z",
+    "created": "2022-10-15T16:44:21.395737Z",
     "gsd": 79,
     "description": "Landsat Collection 2 Level-1",
     "eo:cloud_cover": 58.0,
@@ -505,7 +505,7 @@
     81.05631789666461
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l1/LM04_L1GS_001001_19830527_02_T2/LM04_L1GS_001001_19830527_02_T2.json
+++ b/examples/landsat-c2-l1/LM04_L1GS_001001_19830527_02_T2/LM04_L1GS_001001_19830527_02_T2.json
@@ -7,7 +7,7 @@
     "instruments": [
       "mss"
     ],
-    "created": "2022-03-31T18:25:00.837734Z",
+    "created": "2022-10-15T16:44:22.215016Z",
     "gsd": 79,
     "description": "Landsat Collection 2 Level-1",
     "eo:cloud_cover": 32.0,
@@ -505,7 +505,7 @@
     81.87586682226346
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l1/LM05_L1GS_001001_19850524_02_T2/LM05_L1GS_001001_19850524_02_T2.json
+++ b/examples/landsat-c2-l1/LM05_L1GS_001001_19850524_02_T2/LM05_L1GS_001001_19850524_02_T2.json
@@ -7,7 +7,7 @@
     "instruments": [
       "mss"
     ],
-    "created": "2022-03-31T18:25:00.847685Z",
+    "created": "2022-10-15T16:44:22.222672Z",
     "gsd": 79,
     "description": "Landsat Collection 2 Level-1",
     "eo:cloud_cover": 29.0,
@@ -505,7 +505,7 @@
     81.86973673591433
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l1/collection.json
+++ b/examples/landsat-c2-l1/collection.json
@@ -50,7 +50,7 @@
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
   ],
   "item_assets": {

--- a/examples/landsat-c2-l2/LC08_L2SP_047027_20201204_02_T1/LC08_L2SP_047027_20201204_02_T1.json
+++ b/examples/landsat-c2-l2/LC08_L2SP_047027_20201204_02_T1/LC08_L2SP_047027_20201204_02_T1.json
@@ -8,7 +8,7 @@
       "oli",
       "tirs"
     ],
-    "created": "2022-03-31T14:42:56.958738Z",
+    "created": "2022-10-15T16:44:33.015284Z",
     "gsd": 30,
     "description": "Landsat Collection 2 Level-2",
     "eo:cloud_cover": 1.55,
@@ -1059,12 +1059,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "emsd": {
@@ -1077,12 +1077,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "qa": {
@@ -1111,7 +1111,7 @@
     48.51466487533742
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l2/LC09_L2SP_010065_20220129_02_T1/LC09_L2SP_010065_20220129_02_T1.json
+++ b/examples/landsat-c2-l2/LC09_L2SP_010065_20220129_02_T1/LC09_L2SP_010065_20220129_02_T1.json
@@ -8,7 +8,7 @@
       "oli",
       "tirs"
     ],
-    "created": "2022-03-31T14:42:57.726828Z",
+    "created": "2022-10-15T16:44:34.053490Z",
     "gsd": 30,
     "description": "Landsat Collection 2 Level-2",
     "eo:cloud_cover": 21.12,
@@ -1059,12 +1059,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "emsd": {
@@ -1077,12 +1077,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "qa": {
@@ -1111,7 +1111,7 @@
     -6.181544366336471
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l2/LE07_L2SP_021030_20100109_02_T1/LE07_L2SP_021030_20100109_02_T1.json
+++ b/examples/landsat-c2-l2/LE07_L2SP_021030_20100109_02_T1/LE07_L2SP_021030_20100109_02_T1.json
@@ -7,7 +7,7 @@
     "instruments": [
       "etm+"
     ],
-    "created": "2022-03-31T14:42:56.956079Z",
+    "created": "2022-10-15T16:44:33.012446Z",
     "gsd": 30,
     "description": "Landsat Collection 2 Level-2",
     "eo:cloud_cover": 8.0,
@@ -1010,12 +1010,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "emsd": {
@@ -1028,12 +1028,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "qa": {
@@ -1062,7 +1062,7 @@
     44.160915012330534
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l2/LT04_L2SP_002026_19830110_02_T1/LT04_L2SP_002026_19830110_02_T1.json
+++ b/examples/landsat-c2-l2/LT04_L2SP_002026_19830110_02_T1/LT04_L2SP_002026_19830110_02_T1.json
@@ -7,7 +7,7 @@
     "instruments": [
       "tm"
     ],
-    "created": "2022-03-31T14:42:56.950660Z",
+    "created": "2022-10-15T16:44:33.007031Z",
     "gsd": 30,
     "description": "Landsat Collection 2 Level-2",
     "eo:cloud_cover": 7.0,
@@ -992,12 +992,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "emsd": {
@@ -1010,12 +1010,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "qa": {
@@ -1044,7 +1044,7 @@
     49.87936470319725
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l2/LT05_L2SP_010067_19860424_02_T2/LT05_L2SP_010067_19860424_02_T2.json
+++ b/examples/landsat-c2-l2/LT05_L2SP_010067_19860424_02_T2/LT05_L2SP_010067_19860424_02_T2.json
@@ -7,7 +7,7 @@
     "instruments": [
       "tm"
     ],
-    "created": "2022-03-31T14:42:56.953711Z",
+    "created": "2022-10-15T16:44:33.010202Z",
     "gsd": 30,
     "description": "Landsat Collection 2 Level-2",
     "eo:cloud_cover": 23.0,
@@ -992,12 +992,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "emsd": {
@@ -1010,12 +1010,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "qa": {
@@ -1044,7 +1044,7 @@
     -9.173214387053573
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",

--- a/examples/landsat-c2-l2/collection.json
+++ b/examples/landsat-c2-l2/collection.json
@@ -60,7 +60,7 @@
     "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
   ],
   "item_assets": {
@@ -443,12 +443,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "emsd": {
@@ -460,12 +460,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "qa": {

--- a/src/stactools/landsat/fragments/collections/landsat-c2-l2.json
+++ b/src/stactools/landsat/fragments/collections/landsat-c2-l2.json
@@ -647,12 +647,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "emsd": {
@@ -664,12 +664,12 @@
           "nodata": -9999,
           "data_type": "int16",
           "spatial_resolution": 30,
-          "unit": "emissivity coefficient",
           "scale": 0.0001
         }
       ],
       "roles": [
-        "data"
+        "data",
+        "emissivity"
       ]
     },
     "qa": {

--- a/src/stactools/landsat/fragments/etm/st-assets.json
+++ b/src/stactools/landsat/fragments/etm/st-assets.json
@@ -38,13 +38,13 @@
   "emis": {
     "title": "Emissivity Band",
     "description": "Collection 2 Level-2 Emissivity Band (ST_EMIS) Surface Temperature Product",
-    "roles": ["data"],
+    "roles": ["data", "emissivity"],
     "href_suffix": "ST_EMIS.TIF"
   },
   "emsd": {
     "title": "Emissivity Standard Deviation Band",
     "description": "Collection 2 Level-2 Emissivity Standard Deviation Band (ST_EMSD) Surface Temperature Product",
-    "roles": ["data"],
+    "roles": ["data", "emissivity"],
     "href_suffix": "ST_EMSD.TIF"
   },
   "qa": {

--- a/src/stactools/landsat/fragments/etm/st-raster-bands.json
+++ b/src/stactools/landsat/fragments/etm/st-raster-bands.json
@@ -45,14 +45,12 @@
         "spatial_resolution": 30,
         "data_type": "int16",
         "nodata": -9999,
-        "unit": "emissivity coefficient",
         "scale": 0.0001
     },
     "emsd": {
         "spatial_resolution": 30,
         "data_type": "int16",
         "nodata": -9999,
-        "unit": "emissivity coefficient",
         "scale": 0.0001
     },
     "qa": {

--- a/src/stactools/landsat/fragments/oli_tirs/st-assets.json
+++ b/src/stactools/landsat/fragments/oli_tirs/st-assets.json
@@ -38,13 +38,13 @@
   "emis": {
     "title": "Emissivity Band",
     "description": "Collection 2 Level-2 Emissivity Band (ST_EMIS) Surface Temperature Product",
-    "roles": ["data"],
+    "roles": ["data", "emissivity"],
     "href_suffix": "ST_EMIS.TIF"
   },
   "emsd": {
     "title": "Emissivity Standard Deviation Band",
     "description": "Collection 2 Level-2 Emissivity Standard Deviation Band (ST_EMSD) Surface Temperature Product",
-    "roles": ["data"],
+    "roles": ["data", "emissivity"],
     "href_suffix": "ST_EMSD.TIF"
   },
   "qa": {

--- a/src/stactools/landsat/fragments/oli_tirs/st-raster-bands.json
+++ b/src/stactools/landsat/fragments/oli_tirs/st-raster-bands.json
@@ -45,14 +45,12 @@
         "spatial_resolution": 30,
         "data_type": "int16",
         "nodata": -9999,
-        "unit": "emissivity coefficient",
         "scale": 0.0001
     },
     "emsd": {
         "spatial_resolution": 30,
         "data_type": "int16",
         "nodata": -9999,
-        "unit": "emissivity coefficient",
         "scale": 0.0001
     },
     "qa": {

--- a/src/stactools/landsat/fragments/tm/st-assets.json
+++ b/src/stactools/landsat/fragments/tm/st-assets.json
@@ -38,13 +38,13 @@
   "emis": {
     "title": "Emissivity Band",
     "description": "Collection 2 Level-2 Emissivity Band (ST_EMIS) Surface Temperature Product",
-    "roles": ["data"],
+    "roles": ["data", "emissivity"],
     "href_suffix": "ST_EMIS.TIF"
   },
   "emsd": {
     "title": "Emissivity Standard Deviation Band",
     "description": "Collection 2 Level-2 Emissivity Standard Deviation Band (ST_EMSD) Surface Temperature Product",
-    "roles": ["data"],
+    "roles": ["data", "emissivity"],
     "href_suffix": "ST_EMSD.TIF"
   },
   "qa": {

--- a/src/stactools/landsat/fragments/tm/st-raster-bands.json
+++ b/src/stactools/landsat/fragments/tm/st-raster-bands.json
@@ -45,14 +45,12 @@
         "spatial_resolution": 30,
         "data_type": "int16",
         "nodata": -9999,
-        "unit": "emissivity coefficient",
         "scale": 0.0001
     },
     "emsd": {
         "spatial_resolution": 30,
         "data_type": "int16",
         "nodata": -9999,
-        "unit": "emissivity coefficient",
         "scale": 0.0001
     },
     "qa": {

--- a/tests/test_create_stac.py
+++ b/tests/test_create_stac.py
@@ -128,3 +128,15 @@ def test_no_cloud_cover() -> None:
     # eo:cloud_cover property should not exist
     eo_cloud_cover = item.properties.pop("eo:cloud_cover", None)
     assert eo_cloud_cover is None
+
+
+def test_no_emis_coefficient() -> None:
+    mtl_path = test_data.get_path(
+        "data-files/oli-tirs/LC08_L2SP_047027_20201204_20210313_02_T1_MTL.xml"
+    )
+    item = create_item(mtl_path, use_usgs_geometry=True)
+    item_dict = item.to_dict()
+    assert "emissivity" in item_dict["assets"]["emis"]["roles"]
+    assert "emissivity" in item_dict["assets"]["emsd"]["roles"]
+    assert item_dict["assets"]["emis"]["raster:bands"][0].pop("unit", None) is None
+    assert item_dict["assets"]["emsd"]["raster:bands"][0].pop("unit", None) is None


### PR DESCRIPTION
**Related Issue(s):**
#46 

**Description:**
- Removed unit from `raster:bands` in the `emis` and `emsd` assets in the `c2-l2` Items.
- Added "emissivity" to the asset `roles`
- Added test to verify above changes.

**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [ ] Documentation has been updated to reflect changes, if applicable.
- [x] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
