### PR TITLE
v0.3.0 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,21 +3,21 @@
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args: [--ignore-words=.codespellignore]
         types_or: [jupyter, markdown, python, shell]
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.991
     hooks:
       - id: mypy
         additional_dependencies:
@@ -25,10 +25,10 @@ repos:
           - stactools
           - types-python-dateutil
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.11.4
     hooks:
       - id: isort
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.32.1
+    rev: v0.33.0
     hooks:
       - id: markdownlint

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -8,6 +8,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+Nothing.
+
+### Removed
+
+Nothing.
+
+### Changed
+
+Nothing.
+
+### Fixed
+
+Nothing.
+
+### Deprecated
+
+Nothing.
+
+## [0.3.0] - 2022-10-21
+
+### Added
+
 - "emissivity" to `roles` list on the `emis` and `emsd` assets ([#47](https://github.com/stactools-packages/landsat/pull/47))
 
 ### Removed
@@ -92,7 +114,8 @@ NOTE: For backwards compatibility, all items under the Added, Changed, and Fixed
 
 - Upgrade to stactools 0.2.1.a2 (supporting PySTAC 1.0.0)
 
-[Unreleased]: <https://github.com/stactools-packages/landsat/compare/v0.2.4..main>
+[Unreleased]: <https://github.com/stactools-packages/landsat/compare/v0.3.0..main>
+[0.3.0]: <https://github.com/stactools-packages/landsat/compare/v0.2.4..v0.3.0>
 [0.2.4]: <https://github.com/stactools-packages/landsat/compare/v0.2.3..v0.2.4>
 [0.2.3]: <https://github.com/stactools-packages/landsat/compare/v0.2.2..v0.2.3>
 [0.2.2]: <https://github.com/stactools-packages/landsat/compare/v0.2.1..v0.2.2>

--- a/src/stactools/landsat/__init__.py
+++ b/src/stactools/landsat/__init__.py
@@ -10,4 +10,4 @@ def register_plugin(registry: Registry) -> None:
     registry.register_subcommand(commands.create_landsat_command)
 
 
-__version__ = "0.2.4"
+__version__ = "0.3.0"


### PR DESCRIPTION
**Release Summary**

Added:

- "emissivity" to `roles` list on the `emis` and `emsd` assets ([#47](https://github.com/stactools-packages/landsat/pull/47))

Removed:

- `unit` from the `emis` and `emsd` assets (emissivity coefficient is unitless) ([#47](https://github.com/stactools-packages/landsat/pull/47))
- `legacy_l8` option from Item creation ([#40](https://github.com/stactools-packages/landsat/pull/40))
- Outdated `convert` command ([#40](https://github.com/stactools-packages/landsat/pull/40))
- Unused utility functions: `_parse_date`, `transform_mtl_to_stac`, `transform_stac_to_stac`, `stac_api_to_stac` ([#40](https://github.com/stactools-packages/landsat/pull/40))
- Unused test data files ([#40](https://github.com/stactools-packages/landsat/pull/40))
- Unused docs directory ([#40](https://github.com/stactools-packages/landsat/pull/40))

Changed:

- Item geometry and bbox coordinates rounded to six decimal places ([#45](https://github.com/stactools-packages/landsat/pull/45))
- Renamed `create_stac_item` function to `create_item` ([#40](https://github.com/stactools-packages/landsat/pull/40))


**PR checklist:**

- [x] Code is formatted (run `scripts/format`).
- [x] Code lints properly (run `scripts/lint`).
- [x] Tests pass (run `scripts/test`).
- [x] Documentation has been updated to reflect changes, if applicable.
- [x] Examples have been updated to reflect changes, if applicable
- [x] Changes are added to the [CHANGELOG](../CHANGELOG.md).
