### PR TITLE
deprecate python 3.8, add testing of python 3.12

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     defaults:
       run:
         shell: bash -l {0}

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Deprecated
+
+- Support for Python 3.8 has been dropped.([#64](https://github.com/stactools-packages/landsat/pull/64))
+
 ## [0.4.1] - 2023-08-20
 
 ### Added

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,11 +18,13 @@ keywords =
 classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
+python_requires = >=3.9
 package_dir =
     = src
 packages = find_namespace:


### PR DESCRIPTION
**Related Issue(s):**

n/a

**Description:**

1. Restrict to require Python >=3.9 (previously unrestricted)
2. Test Python 3.12 in CI

**PR checklist:**

- [X] Code is formatted (run `scripts/format`).
- [X] Code lints properly (run `scripts/lint`).
- [X] Tests pass (run `scripts/test`).
- [X] Documentation has been updated to reflect changes, if applicable.
- [X] Examples have been updated to reflect changes, if applicable
- [X] Changes are added to the [CHANGELOG](../CHANGELOG.md).
